### PR TITLE
stylelint-plugin-slds: enhance enforce-bem-usage rule

### DIFF
--- a/packages/stylelint-plugin-slds/package.json
+++ b/packages/stylelint-plugin-slds/package.json
@@ -22,6 +22,7 @@
     "eslint": "8.56.0",
     "glob": "^11.0.1",
     "JSONStream": "^1.3.5",
+    "postcss-selector-parser": "^7.1.0",
     "postcss-values-parser": "^6.0.2",
     "rimraf": "^6.0.1",
     "stylelint": "16.10.0",

--- a/packages/stylelint-plugin-slds/src/rules/enforce-bem-usage/index.ts
+++ b/packages/stylelint-plugin-slds/src/rules/enforce-bem-usage/index.ts
@@ -1,16 +1,22 @@
 import stylelint, { Rule, PostcssResult } from 'stylelint';
 import { readFileSync } from 'fs';
 import { Root } from 'postcss';
+import SelectorParser from 'postcss-selector-parser';
 import { parse } from 'yaml';
 import { metadataFileUrl } from '../../utils/metaDataFileUrl';
 const { utils, createPlugin } = stylelint;
 import ruleMetadata from './../../utils/rulesMetadata';
 import replacePlaceholders from '../../utils/util';
 
+const ruleName: string = 'slds/enforce-bem-usage';
+const selectorParser = SelectorParser();
 
-const ruleName:string = 'slds/enforce-bem-usage';
-
-const { severityLevel = 'error', warningMsg = '', errorMsg = '', ruleDesc = 'No description provided' } = ruleMetadata(ruleName) || {};
+const {
+  severityLevel = 'error',
+  warningMsg = '',
+  errorMsg = '',
+  ruleDesc = 'No description provided',
+} = ruleMetadata(ruleName) || {};
 
 interface Item {
   name: string;
@@ -26,8 +32,8 @@ interface ParsedData {
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
   replaced: (oldValue: string, newValue: string) =>
-    replacePlaceholders(errorMsg, { oldValue, newValue} )
-    //`Consider updating '${oldValue}' to new naming convention '${newValue}'`,
+    replacePlaceholders(errorMsg, { oldValue, newValue }),
+  //`Consider updating '${oldValue}' to new naming convention '${newValue}'`,
 });
 
 const isTestEnv = process.env.NODE_ENV === 'test';
@@ -44,31 +50,39 @@ function validateOptions(result: PostcssResult, options: any): boolean {
 
 function rule(primaryOptions?: any) {
   return (root: Root, result: PostcssResult) => {
-    if (validateOptions(result, primaryOptions))
-    {
+    if (validateOptions(result, primaryOptions)) {
       root.walkRules((rule) => {
-        const givenProp = rule.selector.replace('.', ''); //to remove cases like .slds-text-heading_large
-        if (bemMapping.items[0].tokens[givenProp]) {
-          const index = rule.toString().indexOf(givenProp);
-          const endIndex = index + givenProp.length;
-          const newValue = bemMapping.items[0].tokens[givenProp];
-          const severity =
+        let fixOffset = 0; // aggregate position change if using auto-fix, tracked at the rule level
+        for (const classNode of getClassesFromSelector(rule.selector)) {
+          // check mapping data for this class name
+          const newValue = bemMapping.items[0].tokens[classNode.value];
+          if (newValue) {
+            const index =
+              rule.toString().indexOf(rule.selector) +
+              classNode.sourceIndex +
+              1; // find selector in rule plus '.'
+            const endIndex = index + classNode.value.length;
+            const severity =
               result.stylelint.config.rules[ruleName]?.[1] || severityLevel; // Default to "error"
-          
-          if (typeof newValue === 'string') {
-            stylelint.utils.report({
-              message: messages.replaced(givenProp, newValue),
-              node: rule,
-              index,
-              endIndex,
-              result,
-              ruleName,
-              severity
-            });
+            const fix = () => {
+              rule.selector =
+                rule.selector.substring(0, fixOffset + index) +
+                newValue +
+                rule.selector.substring(fixOffset + endIndex);
+              fixOffset += newValue.length - (endIndex - index);
+            };
 
-            // Call the fix method if in fixing context
-            if (result.stylelint.config.fix) {
-              fix(rule, newValue);
+            if (typeof newValue === 'string') {
+              stylelint.utils.report({
+                message: messages.replaced(classNode.value, newValue),
+                node: rule,
+                index,
+                endIndex,
+                result,
+                ruleName,
+                severity,
+                fix,
+              });
             }
           }
         }
@@ -77,8 +91,15 @@ function rule(primaryOptions?: any) {
   };
 }
 
-function fix(decl: any, newValue: string): void {
-  decl.value = newValue; // Update the declaration value
+function getClassesFromSelector(selector: string) {
+  const selectorAst = selectorParser.astSync(selector);
+  const classNames = [];
+  selectorAst.walkClasses((classNode) => {
+    classNames.push(classNode);
+  });
+  return classNames;
 }
+
+rule.meta = { ruleName, messages, fixable: true };
 
 export default createPlugin(ruleName, rule as unknown as Rule);

--- a/packages/stylelint-plugin-slds/tests/rules/enforce-bem-usage/enforce-bem-usage.spec.ts
+++ b/packages/stylelint-plugin-slds/tests/rules/enforce-bem-usage/enforce-bem-usage.spec.ts
@@ -24,4 +24,180 @@ describe('enforce-bem-usage', () => {
       ).to.equal(message);
     });
   });
+
+  [
+    {
+      description: 'should report and fix bem usage when sole selector',
+      input: `
+        .slds-text-heading_large {
+          border-start-start-radius: 0;
+        }
+      `,
+      expectedOutput: `
+        .slds-text-heading--large {
+          border-start-start-radius: 0;
+        }
+      `,
+      messages: [
+        "Consider updating 'slds-text-heading_large' to new naming convention 'slds-text-heading--large' (slds/enforce-bem-usage)",
+      ],
+      messagePositions: [[1, 24]],
+    },
+    {
+      description: 'should report and fix bem usage when multiple selectors',
+      input: `
+        .slds-dl_horizontal__label,
+        .slds-dl_horizontal__detail {
+          display: none;
+        }
+      `,
+      expectedOutput: `
+        .slds-dl--horizontal__label,
+        .slds-dl--horizontal__detail {
+          display: none;
+        }
+      `,
+      messages: [
+        "Consider updating 'slds-dl_horizontal__label' to new naming convention 'slds-dl--horizontal__label' (slds/enforce-bem-usage)",
+        "Consider updating 'slds-dl_horizontal__detail' to new naming convention 'slds-dl--horizontal__detail' (slds/enforce-bem-usage)",
+      ],
+      messagePositions: [
+        [1, 26],
+        [37, 63],
+      ],
+    },
+    {
+      description: 'should report and fix bem usage in psuedo-selector',
+      input: `
+        .slds-dl_horizontal__label:last-of-type {
+          border-bottom: none;
+        }
+      `,
+      expectedOutput: `
+        .slds-dl--horizontal__label:last-of-type {
+          border-bottom: none;
+        }
+      `,
+      messages: [
+        "Consider updating 'slds-dl_horizontal__label' to new naming convention 'slds-dl--horizontal__label' (slds/enforce-bem-usage)",
+      ],
+      messagePositions: [[1, 26]],
+    },
+    {
+      description: 'should report and fix bem usage in complex selector',
+      input: `
+        div.slds-dl_horizontal__label {
+          border-bottom: none;
+        }
+      `,
+      expectedOutput: `
+        div.slds-dl--horizontal__label {
+          border-bottom: none;
+        }
+      `,
+      messages: [
+        "Consider updating 'slds-dl_horizontal__label' to new naming convention 'slds-dl--horizontal__label' (slds/enforce-bem-usage)",
+      ],
+      messagePositions: [[4, 29]],
+    },
+    {
+      description: 'should report and fix bem usage in chained selector',
+      input: `
+        .slds-dl_horizontal__label div {
+          border-bottom: none;
+        }
+      `,
+      expectedOutput: `
+        .slds-dl--horizontal__label div {
+          border-bottom: none;
+        }
+      `,
+      messages: [
+        "Consider updating 'slds-dl_horizontal__label' to new naming convention 'slds-dl--horizontal__label' (slds/enforce-bem-usage)",
+      ],
+      messagePositions: [[1, 26]],
+    },
+    {
+      description: 'should report and fix bem usage in chained direct selector',
+      input: `
+        .slds-dl_horizontal__label > div {
+          border-bottom: none;
+        }
+      `,
+      expectedOutput: `
+        .slds-dl--horizontal__label > div {
+          border-bottom: none;
+        }
+      `,
+      messages: [
+        "Consider updating 'slds-dl_horizontal__label' to new naming convention 'slds-dl--horizontal__label' (slds/enforce-bem-usage)",
+      ],
+      messagePositions: [[1, 26]],
+    },
+    {
+      description: 'should report and fix bem usage in chained direct selector',
+      input: `
+.slds-dl_horizontal__label, .slds-dl_horizontal__detail {}
+
+.slds-dl_horizontal__label {}
+      `,
+      expectedOutput: `
+.slds-dl--horizontal__label, .slds-dl--horizontal__detail {}
+
+.slds-dl--horizontal__label {}
+      `,
+      messages: [
+        "Consider updating 'slds-dl_horizontal__label' to new naming convention 'slds-dl--horizontal__label' (slds/enforce-bem-usage)",
+        "Consider updating 'slds-dl_horizontal__detail' to new naming convention 'slds-dl--horizontal__detail' (slds/enforce-bem-usage)",
+        "Consider updating 'slds-dl_horizontal__label' to new naming convention 'slds-dl--horizontal__label' (slds/enforce-bem-usage)",
+      ],
+      messagePositions: [
+        [1, 26],
+        [29, 55],
+        [1, 26],
+      ],
+    },
+  ].forEach(
+    (
+      { description, input, expectedOutput, messages, messagePositions },
+      index
+    ) => {
+      it(`Test Case #${index + 1}: ${description}`, async () => {
+        let lintResult = await processLint(input, false);
+
+        // Verify the reported messages
+        // console.log(lintResult._postcssResult.messages);
+        const reportedMessages = lintResult._postcssResult.messages.map(
+          (message) => message.text
+        );
+        expect(reportedMessages).to.have.members(messages);
+        const reportedPositions = lintResult._postcssResult.messages.map(
+          (message) => [message.index, message.endIndex]
+        );
+        expect(reportedPositions).to.have.deep.members(messagePositions);
+
+        lintResult = await processLint(input, true);
+
+        expect(lintResult._postcssResult.root.toString()).to.equal(
+          expectedOutput
+        );
+      });
+    }
+  );
 });
+
+async function processLint(input: string, fixable = false) {
+  const linterOptions: LinterOptions = {
+    code: input,
+    config: {
+      plugins: ['./src/index.ts'], // Adjust path as needed
+      rules: {
+        'slds/enforce-bem-usage': true,
+      },
+      fix: fixable,
+    },
+  };
+
+  const result: LinterResult = await lint(linterOptions);
+  return result.results[0];
+}


### PR DESCRIPTION
Adds a new dependency, `postcss-selector-parser`, so we can breakdown the selectors and fish out the class names.

Add support for much more complicated selectors and add supporting tests.