### PR TITLE
Integrate @salesforce-ux/slds-linter for Global Linting in Consumer App

### DIFF
--- a/packages/slds-linter/bin/slds-linter.js
+++ b/packages/slds-linter/bin/slds-linter.js
@@ -7,18 +7,10 @@ import chalk from 'chalk';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-// // ✅ Fix: Get __dirname in ES modules
-// const __filename = fileURLToPath(import.meta.url);
-// const __dirname = path.dirname(__filename);
-
-// Define paths for built-in configurations
-// const eslintConfigPath = path.resolve(__dirname, '../build/.eslintrc.yml');
-// const stylelintConfigPath = path.resolve(__dirname, '../build/.stylelintrc.yml');
-
 const eslintConfigPath = fileURLToPath(await import.meta.resolve('@salesforce-ux/eslint-plugin-slds/build/.eslintrc.yml'));
 const stylelintConfigPath = fileURLToPath(await import.meta.resolve('@salesforce-ux/stylelint-plugin-slds/build/.stylelintrc.yml'));
 
-// Command-line arguments handling
+// ✅ Define CLI Commands using `yargs`
 yargs(hideBin(process.argv))
     .command(
         'lint',
@@ -27,11 +19,42 @@ yargs(hideBin(process.argv))
         () => {
             console.log(chalk.cyan('🔍 Running ESLint and Stylelint...'));
             try {
-                execSync(`eslint . --config ${eslintConfigPath} --ext .js,.jsx,.ts,.tsx,.html,.cmp`, { stdio: 'inherit' });
-                execSync(`stylelint "**/*.css" --config ${stylelintConfigPath}`, { stdio: 'inherit' });
+                execSync(`eslint **/*.{html,cmp} --config ${eslintConfigPath} --ext .html,.cmp`, { stdio: 'inherit' });
+                execSync(`stylelint ./**/*.css --config ${stylelintConfigPath}`, { stdio: 'inherit' });
                 console.log(chalk.green('✅ Linting completed successfully!'));
             } catch (error) {
                 console.error(chalk.red('❌ Linting failed. Please fix the errors and try again.'));
+                process.exit(1);
+            }
+        }
+    )
+    .command(
+        'lint:styles',
+        'Run only Stylelint',
+        () => {},
+        () => {
+            console.log(chalk.cyan('🎨 Running Stylelint...'));
+            try {
+                execSync(`stylelint ./**/*.css --config ${stylelintConfigPath}`, { stdio: 'inherit' });
+                console.log(chalk.green('✅ Stylelint completed successfully!'));
+            } catch (error) {
+                console.error(chalk.red('❌ Stylelint failed. Please fix the errors and try again.'));
+                process.exit(1);
+            }
+        }
+    )
+    .command(
+        'lint:components',
+        'Run only ESLint',
+        () => {},
+        () => {
+            console.log(chalk.cyan('🛠️ Running ESLint...'));
+            try {
+                execSync(`eslint **/*.{html,cmp} --config ${eslintConfigPath} --ext .html,.cmp`, { stdio: 'inherit' });
+                console.log(chalk.green('✅ ESLint completed successfully!'));
+            } catch (error) {
+                console.error(chalk.red('❌ ESLint failed. Please fix the errors and try again.'));
+                process.exit(1);
             }
         }
     )
@@ -42,11 +65,12 @@ yargs(hideBin(process.argv))
         () => {
             console.log(chalk.cyan('🔧 Running auto-fix for ESLint and Stylelint...'));
             try {
-                execSync(`eslint . --config ${eslintConfigPath} --fix --ext .js,.jsx,.ts,.tsx,.html,.cmp`, { stdio: 'inherit' });
-                execSync(`stylelint "**/*.css" --config ${stylelintConfigPath} --fix`, { stdio: 'inherit' });
+                execSync(`eslint **/*.{html,cmp} --config ${eslintConfigPath} --fix --ext .html,.cmp`, { stdio: 'inherit' });
+                execSync(`stylelint "**/*.css" -c ${stylelintConfigPath} --fix`, { stdio: 'inherit' });
                 console.log(chalk.green('✅ Auto-fix applied successfully!'));
             } catch (error) {
                 console.error(chalk.red('❌ Fixing failed. Please check linting errors.'));
+                process.exit(1);
             }
         }
     )
@@ -64,10 +88,11 @@ yargs(hideBin(process.argv))
         (argv) => {
             console.log(chalk.cyan(`📊 Generating linting report for ${argv.dir}...`));
             try {
-                execSync(`node node_modules/@salesforce-ux/stylelint-sds/build/report.js ${argv.dir} -c ${stylelintConfigPath}`, { stdio: 'inherit' });
+                execSync(`node node_modules/@salesforce-ux/stylelint-plugin-slds/build/report.js ${argv.dir} -c ${stylelintConfigPath}`, { stdio: 'inherit' });
                 console.log(chalk.green('✅ Report generated successfully!'));
             } catch (error) {
                 console.error(chalk.red('❌ Failed to generate the report.'));
+                process.exit(1);
             }
         }
     )

--- a/packages/slds-linter/bin/slds-linter.js
+++ b/packages/slds-linter/bin/slds-linter.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import chalk from 'chalk';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+// // ✅ Fix: Get __dirname in ES modules
+// const __filename = fileURLToPath(import.meta.url);
+// const __dirname = path.dirname(__filename);
+
+// Define paths for built-in configurations
+// const eslintConfigPath = path.resolve(__dirname, '../build/.eslintrc.yml');
+// const stylelintConfigPath = path.resolve(__dirname, '../build/.stylelintrc.yml');
+
+const eslintConfigPath = fileURLToPath(await import.meta.resolve('@salesforce-ux/eslint-plugin-slds/build/.eslintrc.yml'));
+const stylelintConfigPath = fileURLToPath(await import.meta.resolve('@salesforce-ux/stylelint-plugin-slds/build/.stylelintrc.yml'));
+
+// Command-line arguments handling
+yargs(hideBin(process.argv))
+    .command(
+        'lint',
+        'Run both ESLint and Stylelint',
+        () => {},
+        () => {
+            console.log(chalk.cyan('🔍 Running ESLint and Stylelint...'));
+            try {
+                execSync(`eslint . --config ${eslintConfigPath} --ext .js,.jsx,.ts,.tsx,.html,.cmp`, { stdio: 'inherit' });
+                execSync(`stylelint "**/*.css" --config ${stylelintConfigPath}`, { stdio: 'inherit' });
+                console.log(chalk.green('✅ Linting completed successfully!'));
+            } catch (error) {
+                console.error(chalk.red('❌ Linting failed. Please fix the errors and try again.'));
+            }
+        }
+    )
+    .command(
+        'fix',
+        'Fix auto-fixable issues',
+        () => {},
+        () => {
+            console.log(chalk.cyan('🔧 Running auto-fix for ESLint and Stylelint...'));
+            try {
+                execSync(`eslint . --config ${eslintConfigPath} --fix --ext .js,.jsx,.ts,.tsx,.html,.cmp`, { stdio: 'inherit' });
+                execSync(`stylelint "**/*.css" --config ${stylelintConfigPath} --fix`, { stdio: 'inherit' });
+                console.log(chalk.green('✅ Auto-fix applied successfully!'));
+            } catch (error) {
+                console.error(chalk.red('❌ Fixing failed. Please check linting errors.'));
+            }
+        }
+    )
+    .command(
+        'report',
+        'Generate a linting report',
+        (yargs) => {
+            return yargs.option('dir', {
+                alias: 'd',
+                describe: 'Target directory for linting',
+                type: 'string',
+                default: 'force-app/'
+            });
+        },
+        (argv) => {
+            console.log(chalk.cyan(`📊 Generating linting report for ${argv.dir}...`));
+            try {
+                execSync(`node node_modules/@salesforce-ux/stylelint-sds/build/report.js ${argv.dir} -c ${stylelintConfigPath}`, { stdio: 'inherit' });
+                console.log(chalk.green('✅ Report generated successfully!'));
+            } catch (error) {
+                console.error(chalk.red('❌ Failed to generate the report.'));
+            }
+        }
+    )
+    .help()
+    .argv;

--- a/packages/slds-linter/package.json
+++ b/packages/slds-linter/package.json
@@ -25,7 +25,9 @@
     "type": "module",
     "dependencies": {
         "@salesforce-ux/eslint-plugin-slds": "latest",
-        "@salesforce-ux/stylelint-plugin-slds": "latest"
+        "@salesforce-ux/stylelint-plugin-slds": "latest",
+        "chalk": "^5.3.0",
+        "yargs": "^17.7.2"
     },
     "keywords": [
         "eslint SDS",

--- a/packages/slds-linter/package.json
+++ b/packages/slds-linter/package.json
@@ -3,12 +3,16 @@
     "version": "0.0.8",
     "description": "SLDS Linter with both stylelint and eslint together",
     "main": "index.mjs",
+    "bin": {
+        "slds-linter": "./bin/slds-linter.js"
+    },
     "workspaces": [
         "packages/*"
     ],
     "access": "public",
     "files": [
         "build/",
+        "bin/",
         "README.md"
     ],
     "scripts": {


### PR DESCRIPTION

<img width="1696" alt="Screenshot 2025-02-14 at 6 57 42 PM" src="https://github.com/user-attachments/assets/4a431958-7841-4c70-838e-8c242832b0cd" />


PR Title
Enhance Global Linting in Consumer App with @salesforce-ux/slds-linter

PR Description
This PR integrates @salesforce-ux/slds-linter using npx, enabling seamless global accessibility for SLDS linting across the consumer app.

Testing:

Packaged and published as a tarball.
Installed locally in the stylelint-slds-content-repo for validation.

Test the CLI in any consumer app after installing  @salesforce-ux/slds-linter :
Now, try running:

npx @salesforce-ux/slds-linter lint

or any other command:

npx @salesforce-ux/slds-linter report --dir src/

