### PR TITLE
Linting results are printed

### DIFF
--- a/packages/linter-cli/src/commands/lint-components.ts
+++ b/packages/linter-cli/src/commands/lint-components.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import path from 'path';
 import { CliOptions } from '../types';
+import { printLintResults } from '../utils/lintResultsUtil';
 import { getEditorLink, createClickableLineCol } from '../utils/editorLinkUtil';
 import { normalizeCliOptions } from '../utils/cli-args';
 import { Logger } from '../utils/logger';
@@ -39,42 +40,7 @@ export function registerLintComponentsCommand(program: Command): void {
         });
 
         // Print results only for files with issues
-        results.forEach(result => {
-          const hasErrors = result.errors?.length > 0;
-          const hasWarnings = result.warnings?.length > 0;
-          if (!hasErrors && !hasWarnings) return;
-
-          const absolutePath = result.filePath || '';
-          const relativeFile = path.relative(process.cwd(), absolutePath) || 'Unknown file';
-          // Print file name with a blank line before for spacing
-          Logger.info(`\n${chalk.bold(relativeFile)}`);
-
-          if (hasErrors) {
-            result.errors.forEach(error => {
-              if (error.line && error.column && absolutePath) {
-                const lineCol = `${error.line}:${error.column}`;
-                const clickable = createClickableLineCol(lineCol, absolutePath, error.line, error.column, normalizedOptions.editor);
-                const ruleId = error.ruleId ? chalk.dim(error.ruleId) : '';
-                Logger.error(`  ${clickable}  ${error.message}  ${ruleId}`);
-              } else {
-                Logger.error(`  ${chalk.red('Error:')} ${error.message}`);
-              }
-            });
-          }
-
-          if (hasWarnings) {
-            result.warnings.forEach(warning => {
-              if (warning.line && warning.column && absolutePath) {
-                const lineCol = `${warning.line}:${warning.column}`;
-                const clickable = createClickableLineCol(lineCol, absolutePath, warning.line, warning.column, normalizedOptions.editor);
-                const ruleId = warning.ruleId ? chalk.dim(warning.ruleId) : '';
-                Logger.warning(`  ${clickable}  ${warning.message}  ${ruleId}`);
-              } else {
-                Logger.warning(`  ${chalk.yellow('Warning:')} ${warning.message}`);
-              }
-            });
-          }
-        });
+        printLintResults(results, normalizedOptions.editor);
 
         const errorCount = results.reduce((sum, r) => sum + r.errors.length, 0);
         const warningCount = results.reduce((sum, r) => sum + r.warnings.length, 0);

--- a/packages/linter-cli/src/commands/lint-styles.ts
+++ b/packages/linter-cli/src/commands/lint-styles.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import path from 'path';
 import { CliOptions } from '../types';
+import { printLintResults } from '../utils/lintResultsUtil';
 import { getEditorLink, createClickableLineCol } from '../utils/editorLinkUtil';
 import { normalizeCliOptions } from '../utils/cli-args';
 import { Logger } from '../utils/logger';
@@ -39,41 +40,7 @@ export function registerLintStylesCommand(program: Command): void {
         });
 
         // Print detailed lint results only for files with issues
-        results.forEach(result => {
-          const hasErrors = result.errors?.length > 0;
-          const hasWarnings = result.warnings?.length > 0;
-          if (!hasErrors && !hasWarnings) return;
-
-          const absolutePath = result.filePath || '';
-          const relativeFile = path.relative(process.cwd(), absolutePath) || 'Unknown file';
-          Logger.info(`\n${chalk.bold(relativeFile)}`);
-
-          if (hasErrors) {
-            result.errors?.forEach(err => {
-              if (err.line && err.column && absolutePath) {
-                const lineCol = `${err.line}:${err.column}`;
-                const clickable = createClickableLineCol(lineCol, absolutePath, err.line, err.column, normalizedOptions.editor);
-                const ruleId = err.ruleId ? chalk.dim(err.ruleId) : '';
-                Logger.error(`  ${clickable}  ${err.message}  ${ruleId}`);
-              } else {
-                Logger.error(`  ${chalk.red('Error:')} ${err.message}`);
-              }
-            });
-          }
-
-          if (hasWarnings) {
-            result.warnings?.forEach(warn => {
-              if (warn.line && warn.column && absolutePath) {
-                const lineCol = `${warn.line}:${warn.column}`;
-                const clickable = createClickableLineCol(lineCol, absolutePath, warn.line, warn.column, normalizedOptions.editor);
-                const ruleId = warn.ruleId ? chalk.dim(warn.ruleId) : '';
-                Logger.warning(`  ${clickable}  ${warn.message}  ${ruleId}`);
-              } else {
-                Logger.warning(`  ${chalk.yellow('Warning:')} ${warn.message}`);
-              }
-            });
-          }
-        });
+        printLintResults(results, normalizedOptions.editor);
 
         const errorCount = results.reduce((sum, r) => sum + r.errors.length, 0);
         const warningCount = results.reduce((sum, r) => sum + r.warnings.length, 0);

--- a/packages/linter-cli/src/commands/lint.ts
+++ b/packages/linter-cli/src/commands/lint.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import path from 'path';
 import { CliOptions } from '../types';
 import { getEditorLink, createClickableLineCol } from '../utils/editorLinkUtil';
+import { printLintResults } from '../utils/lintResultsUtil';
 import { normalizeCliOptions } from '../utils/cli-args';
 import { Logger } from '../utils/logger';
 import { FileScanner } from '../services/file-scanner';
@@ -81,28 +82,7 @@ export function registerLintCommand(program: Command): void {
         });
 
         // Print component lint issues (only for files with issues)
-        componentResults.forEach(result => {
-          const hasErrors = result.errors?.length > 0;
-          const hasWarnings = result.warnings?.length > 0;
-          if (!hasErrors && !hasWarnings) return;
-
-          const absolutePath = result.filePath || '';
-          const relativeFile = path.relative(process.cwd(), absolutePath) || 'Unknown file';
-          Logger.info(`\n${chalk.bold(relativeFile)}`);
-
-          result.errors?.forEach(err => {
-            const lineCol = `${err.line}:${err.column}`;
-            const clickable = createClickableLineCol(lineCol, absolutePath, err.line, err.column, normalizedOptions.editor);
-            const ruleId = err.ruleId ? chalk.dim(err.ruleId) : '';
-            Logger.error(`  ${clickable}  ${err.message}  ${ruleId}`);
-          });
-          result.warnings?.forEach(warn => {
-            const lineCol = `${warn.line}:${warn.column}`;
-            const clickable = createClickableLineCol(lineCol, absolutePath, warn.line, warn.column, normalizedOptions.editor);
-            const ruleId = warn.ruleId ? chalk.dim(warn.ruleId) : '';
-            Logger.warning(`  ${clickable}  ${warn.message}  ${ruleId}`);
-          });
-        });
+        printLintResults(componentResults, normalizedOptions.editor);
 
         const componentErrorCount = componentResults.reduce((sum, r) => sum + r.errors.length, 0);
         const componentWarningCount = componentResults.reduce((sum, r) => sum + r.warnings.length, 0);

--- a/packages/linter-cli/src/commands/lint.ts
+++ b/packages/linter-cli/src/commands/lint.ts
@@ -1,5 +1,8 @@
 import { Command } from 'commander';
+import chalk from 'chalk';
+import path from 'path';
 import { CliOptions } from '../types';
+import { getEditorLink, createClickableLineCol } from '../utils/editorLinkUtil';
 import { normalizeCliOptions } from '../utils/cli-args';
 import { Logger } from '../utils/logger';
 import { FileScanner } from '../services/file-scanner';
@@ -11,58 +14,112 @@ export function registerLintCommand(program: Command): void {
   program
     .command('lint')
     .description('Run both style and component linting')
-    .option('-d, --directory <path>', 'Target directory to scan (defaults to current directory)')    
+    .option('-d, --directory <path>', 'Target directory to scan (defaults to current directory)')
     .option('--fix', 'Automatically fix problems')
     .option('--config-style <path>', 'Path to stylelint config file', DEFAULT_STYLELINT_CONFIG_PATH)
     .option('--config-eslint <path>', 'Path to eslint config file', DEFAULT_ESLINT_CONFIG_PATH)
+    .option('--editor <editor>', 'Editor to open files with (e.g., vscode, atom, sublime). Defaults to vscode', 'vscode')
     .action(async (options: CliOptions) => {
+      const startTime = Date.now();
       try {
-        Logger.info('Starting full linting process...');
+        Logger.info(chalk.blue('Starting full linting process...'));
         const normalizedOptions = normalizeCliOptions(options);
-        
-        // Scan style files
-        Logger.info('Starting style files scan...');
+
+        // 1) STYLE LINT
+        Logger.info(chalk.blue('\nScanning style files...'));
         const styleFileBatches = await FileScanner.scanFiles(normalizedOptions.directory, {
           patterns: StyleFilePatterns,
-          batchSize: 100
+          batchSize: 100,
         });
-        
-        Logger.info(`Found ${styleFileBatches.reduce((sum, batch) => sum + batch.length, 0)} style files to lint`);
-        
+        const totalStyleFiles = styleFileBatches.reduce((sum, batch) => sum + batch.length, 0);
+        Logger.info(chalk.blue(`Found ${totalStyleFiles} style file(s). Running stylelint...\n`));
+
         const styleResults = await LintRunner.runLinting(styleFileBatches, 'style', {
           fix: options.fix,
-          configPath: options.configStyle
+          configPath: options.configStyle,
         });
-        
+
+        // Print style lint issues (only for files with issues)
+        styleResults.forEach(result => {
+          const hasErrors = result.errors?.length > 0;
+          const hasWarnings = result.warnings?.length > 0;
+          if (!hasErrors && !hasWarnings) return;
+
+          const absolutePath = result.filePath || '';
+          const relativeFile = path.relative(process.cwd(), absolutePath) || 'Unknown file';
+          Logger.info(`\n${chalk.bold(relativeFile)}`);
+
+          result.errors?.forEach(err => {
+            const lineCol = `${err.line}:${err.column}`;
+            const clickable = createClickableLineCol(lineCol, absolutePath, err.line, err.column, normalizedOptions.editor);
+            const ruleId = err.ruleId ? chalk.dim(err.ruleId) : '';
+            Logger.error(`  ${clickable}  ${err.message}  ${ruleId}`);
+          });
+          result.warnings?.forEach(warn => {
+            const lineCol = `${warn.line}:${warn.column}`;
+            const clickable = createClickableLineCol(lineCol, absolutePath, warn.line, warn.column, normalizedOptions.editor);
+            const ruleId = warn.ruleId ? chalk.dim(warn.ruleId) : '';
+            Logger.warning(`  ${clickable}  ${warn.message}  ${ruleId}`);
+          });
+        });
+
         const styleErrorCount = styleResults.reduce((sum, r) => sum + r.errors.length, 0);
         const styleWarningCount = styleResults.reduce((sum, r) => sum + r.warnings.length, 0);
-        
-        Logger.info(`Style files: ${styleErrorCount} errors and ${styleWarningCount} warnings`);
-        
-        // Scan component files
-        Logger.info('Starting component files scan...');
+
+        // 2) COMPONENT LINT
+        Logger.info(chalk.blue('\nScanning component files...'));
         const componentFileBatches = await FileScanner.scanFiles(normalizedOptions.directory, {
           patterns: ComponentFilePatterns,
-          batchSize: 100
+          batchSize: 100,
         });
-        
-        Logger.info(`Found ${componentFileBatches.reduce((sum, batch) => sum + batch.length, 0)} component files to lint`);
-        
+        const totalComponentFiles = componentFileBatches.reduce((sum, batch) => sum + batch.length, 0);
+        Logger.info(chalk.blue(`Found ${totalComponentFiles} component file(s). Running eslint...\n`));
+
         const componentResults = await LintRunner.runLinting(componentFileBatches, 'component', {
           fix: options.fix,
-          configPath: options.configEslint
+          configPath: options.configEslint,
         });
-        
+
+        // Print component lint issues (only for files with issues)
+        componentResults.forEach(result => {
+          const hasErrors = result.errors?.length > 0;
+          const hasWarnings = result.warnings?.length > 0;
+          if (!hasErrors && !hasWarnings) return;
+
+          const absolutePath = result.filePath || '';
+          const relativeFile = path.relative(process.cwd(), absolutePath) || 'Unknown file';
+          Logger.info(`\n${chalk.bold(relativeFile)}`);
+
+          result.errors?.forEach(err => {
+            const lineCol = `${err.line}:${err.column}`;
+            const clickable = createClickableLineCol(lineCol, absolutePath, err.line, err.column, normalizedOptions.editor);
+            const ruleId = err.ruleId ? chalk.dim(err.ruleId) : '';
+            Logger.error(`  ${clickable}  ${err.message}  ${ruleId}`);
+          });
+          result.warnings?.forEach(warn => {
+            const lineCol = `${warn.line}:${warn.column}`;
+            const clickable = createClickableLineCol(lineCol, absolutePath, warn.line, warn.column, normalizedOptions.editor);
+            const ruleId = warn.ruleId ? chalk.dim(warn.ruleId) : '';
+            Logger.warning(`  ${clickable}  ${warn.message}  ${ruleId}`);
+          });
+        });
+
         const componentErrorCount = componentResults.reduce((sum, r) => sum + r.errors.length, 0);
         const componentWarningCount = componentResults.reduce((sum, r) => sum + r.warnings.length, 0);
-        
-        Logger.info(`Component files: ${componentErrorCount} errors and ${componentWarningCount} warnings`);
-        
-        Logger.success('Full linting completed');
-        process.exit(styleErrorCount + componentErrorCount > 0 ? 1 : 0);
+
+        // Final summary
+        const totalErrors = styleErrorCount + componentErrorCount;
+        const totalWarnings = styleWarningCount + componentWarningCount;
+        Logger.info(
+          `\n${chalk.red(`${totalErrors} error${totalErrors !== 1 ? 's' : ''}`)}` +
+          `  ${chalk.yellow(`${totalWarnings} warning${totalWarnings !== 1 ? 's' : ''}`)}`
+        );
+        const elapsedTime = ((Date.now() - startTime) / 1000).toFixed(2);
+        Logger.success(chalk.green(`\nFull linting completed in ${elapsedTime} seconds.`));
+        process.exit(totalErrors > 0 ? 1 : 0);
       } catch (error: any) {
-        Logger.error(`Failed to complete linting: ${error.message}`);
+        Logger.error(chalk.red(`Failed to complete linting: ${error.message}`));
         process.exit(1);
       }
     });
-} 
+}

--- a/packages/linter-cli/src/types/index.ts
+++ b/packages/linter-cli/src/types/index.ts
@@ -5,6 +5,7 @@ export interface CliOptions {
   config?: string; // Used for stylelint config, eslint config when command is lint:styles or lint:components
   configStyle?: string; // Used for stylelint config when command is lint
   configEslint?: string; // Used for eslint config when command is lint
+  editor?: string;
 }
 
 export interface LintResult {

--- a/packages/linter-cli/src/utils/cli-args.ts
+++ b/packages/linter-cli/src/utils/cli-args.ts
@@ -25,6 +25,7 @@ export function normalizeCliOptions(options: CliOptions): Required<CliOptions> {
     fix: options.fix || false,
     config: options.config || '',
     configStyle: options.configStyle || '',
-    configEslint: options.configEslint || ''
+    configEslint: options.configEslint || '',
+    editor: options.editor || 'vscode'
   };
 } 

--- a/packages/linter-cli/src/utils/editorLinkUtil.ts
+++ b/packages/linter-cli/src/utils/editorLinkUtil.ts
@@ -1,0 +1,52 @@
+// src/utils/editorLinkUtil.ts
+
+import chalk from 'chalk';
+
+/**
+ * Returns an editor-specific link for opening a file at a given line and column.
+ *
+ * @param editor - The editor to use (e.g., 'vscode', 'atom', 'sublime').
+ * @param absolutePath - The absolute path to the file.
+ * @param line - The line number in the file.
+ * @param column - The column number in the file.
+ * @returns A URL string that can be used to open the file in the specified editor.
+ */
+export function getEditorLink(
+  editor: string,
+  absolutePath: string,
+  line: number,
+  column: number
+): string {
+  if (editor === 'vscode') {
+    return `vscode://file/${absolutePath}:${line}:${column}`;
+  } else if (editor === 'atom') {
+    return `atom://core/open/file?filename=${absolutePath}&line=${line}&column=${column}`;
+  } else if (editor === 'sublime') {
+    // Sublime Text does not have a standard URL scheme.
+    return `file://${absolutePath}:${line}:${column}`;
+  } else {
+    // Fallback to a standard file URL.
+    return `file://${absolutePath}:${line}:${column}`;
+  }
+}
+
+/**
+ * Creates an ANSI hyperlink (if supported) for the line:column text.
+ *
+ * @param lineCol - The line:column string (e.g., "10:5").
+ * @param absolutePath - The absolute path to the file.
+ * @param line - The line number in the file.
+ * @param column - The column number in the file.
+ * @param editor - The editor to use (e.g., 'vscode', 'atom', 'sublime').
+ * @returns A string with ANSI escape sequences to create a clickable hyperlink.
+ */
+export function createClickableLineCol(
+  lineCol: string,
+  absolutePath: string,
+  line: number,
+  column: number,
+  editor: string
+): string {
+  const link = getEditorLink(editor, absolutePath, line, column);
+  return `\u001b]8;;${link}\u0007${chalk.blueBright(lineCol)}\u001b]8;;\u0007`;
+}

--- a/packages/linter-cli/src/utils/lintResultsUtil.ts
+++ b/packages/linter-cli/src/utils/lintResultsUtil.ts
@@ -1,0 +1,51 @@
+// src/utils/lintResultsUtil.ts
+
+import chalk from 'chalk';
+import path from 'path';
+import { createClickableLineCol } from './editorLinkUtil';
+import { Logger } from '../utils/logger';
+
+/**
+ * Prints detailed lint results for each file that has issues.
+ *
+ * @param results - Array of lint results.
+ * @param editor - The chosen editor for clickable links (e.g., "vscode", "atom", "sublime").
+ */
+export function printLintResults(results: any[], editor: string): void {
+  results.forEach(result => {
+    const hasErrors = result.errors && result.errors.length > 0;
+    const hasWarnings = result.warnings && result.warnings.length > 0;
+    if (!hasErrors && !hasWarnings) return;
+
+    const absolutePath = result.filePath || '';
+    const relativeFile = path.relative(process.cwd(), absolutePath) || 'Unknown file';
+    // Print file name with a preceding new line for spacing.
+    Logger.info(`\n${chalk.bold(relativeFile)}`);
+
+    if (hasErrors) {
+      result.errors.forEach((error: any) => {
+        if (error.line && error.column && absolutePath) {
+          const lineCol = `${error.line}:${error.column}`;
+          const clickable = createClickableLineCol(lineCol, absolutePath, error.line, error.column, editor);
+          const ruleId = error.ruleId ? chalk.dim(error.ruleId) : '';
+          Logger.error(`  ${clickable}  ${error.message}  ${ruleId}`);
+        } else {
+          Logger.error(`  ${chalk.red('Error:')} ${error.message}`);
+        }
+      });
+    }
+
+    if (hasWarnings) {
+      result.warnings.forEach((warn: any) => {
+        if (warn.line && warn.column && absolutePath) {
+          const lineCol = `${warn.line}:${warn.column}`;
+          const clickable = createClickableLineCol(lineCol, absolutePath, warn.line, warn.column, editor);
+          const ruleId = warn.ruleId ? chalk.dim(warn.ruleId) : '';
+          Logger.warning(`  ${clickable}  ${warn.message}  ${ruleId}`);
+        } else {
+          Logger.warning(`  ${chalk.yellow('Warning:')} ${warn.message}`);
+        }
+      });
+    }
+  });
+}


### PR DESCRIPTION
New Utility:
Created editorLinkUtil.ts exporting two functions:

getEditorLink: Generates an editor-specific URL (supports vscode, atom, sublime, and a fallback).
createClickableLineCol: Wraps the line:column text in an ANSI hyperlink.
Updated Commands:
Modified both component and style lint commands to:

Use relative file paths.
Skip files with no issues.
Display clickable line:column links based on the user's chosen editor (via a new --editor option, defaulting to vscode).
Impact
These changes enhance UX by allowing developers to click a line:column reference in the terminal to directly open the file in their preferred editor.

Demo: https://salesforce-internal.slack.com/archives/C08AY1F3UAW/p1740404564508619?thread_ts=1740387665.069089&cid=C08AY1F3UAW
