### PR TITLE
fix(slds-linter): avoid loading package json

### DIFF
--- a/packages/slds-linter/src/index.ts
+++ b/packages/slds-linter/src/index.ts
@@ -8,7 +8,6 @@ import { registerReportCommand } from './commands/report';
 import { registerEmitCommand } from './commands/emit';
 import { Logger } from './utils/logger';
 import { validateNodeVersion } from './utils/nodeVersionUtil';
-import { version } from 'os';
 
 // Validate Node.js version before proceeding
 validateNodeVersion();

--- a/packages/slds-linter/src/index.ts
+++ b/packages/slds-linter/src/index.ts
@@ -8,7 +8,7 @@ import { registerReportCommand } from './commands/report';
 import { registerEmitCommand } from './commands/emit';
 import { Logger } from './utils/logger';
 import { validateNodeVersion } from './utils/nodeVersionUtil';
-import pkg from '../package.json' with {type:"json"};
+//import pkg from '../package.json' with {type:"json"};
 
 // Validate Node.js version before proceeding
 validateNodeVersion();
@@ -27,8 +27,9 @@ const program = new Command();
 
 program
   .name('npx @salesforce-ux/slds-linter@latest')
-  .description(pkg.description)
-  .version(pkg.version)
+  // TODO: emable -V and description later
+  //.description(pkg.description)
+  //.version(pkg.version)
   .showHelpAfterError();
 
 registerLintStylesCommand(program);

--- a/packages/slds-linter/src/index.ts
+++ b/packages/slds-linter/src/index.ts
@@ -8,7 +8,7 @@ import { registerReportCommand } from './commands/report';
 import { registerEmitCommand } from './commands/emit';
 import { Logger } from './utils/logger';
 import { validateNodeVersion } from './utils/nodeVersionUtil';
-//import pkg from '../package.json' with {type:"json"};
+import { version } from 'os';
 
 // Validate Node.js version before proceeding
 validateNodeVersion();
@@ -27,15 +27,23 @@ const program = new Command();
 
 program
   .name('npx @salesforce-ux/slds-linter@latest')
-  // TODO: emable -V and description later
-  //.description(pkg.description)
-  //.version(pkg.version)
   .showHelpAfterError();
+
+function registerVersion(){
+  //TODO: Not an optimised way of doing. will review later
+  let pkg = {description:'', version:''};
+  try{
+    pkg = require("../package.json")
+  }catch(e){}
+  program.description(pkg.description)
+  .version(pkg.version);
+}
 
 registerLintStylesCommand(program);
 registerLintComponentsCommand(program);
 registerLintCommand(program);
 registerReportCommand(program);
 registerEmitCommand(program);
+registerVersion();
 
 program.parse(process.argv); 

--- a/packages/slds-linter/src/utils/cli-args.ts
+++ b/packages/slds-linter/src/utils/cli-args.ts
@@ -26,6 +26,7 @@ export function normalizeCliOptions(options: CliOptions, defultOptions:Partial<C
     configStyle:'',
     configEslint:'',
     ...defultOptions,
+    ...options,
     directory: validateAndNormalizePath(options.directory),
     output: validateAndNormalizePath(options.output)
   };


### PR DESCRIPTION
- loading package json failes in node < v20
- TODO: check better alternate instead of importing
-  using cjs require to load package.json